### PR TITLE
fix: set GITHUB_TOKEN for sbt command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -84,6 +84,8 @@ runs:
 
     - name: Generate Dependency Tree
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
         mkdir -p ${{ inputs.report-dir }}
         sbt dependencyBrowseTreeHTML


### PR DESCRIPTION
needed when the context of execution is a private repository