### PR TITLE
refactor: sec-scan-report more flexible

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -141,9 +141,9 @@ runs:
       shell: bash
       run: |
         ${{ github.action_path }}/scripts/sec-scan-report \
-          ${{ inputs.report-dir }}/vulnerabilities.json \
-          ${{ inputs.report-dir }}/deptree.json \
-          ${{ inputs.report-dir }}/vulnerabilities.md
+          -t ${{ inputs.report-dir }}/vulnerabilities.json \
+          -o ${{ inputs.report-dir }}/vulnerabilities.md \
+          -d ${{ inputs.report-dir }}/deptree.json
 
         # Add issue link to summary if issue exists or was created
         if [ -n "${{ steps.check_report.outputs.issue-number }}" ]; then

--- a/scripts/sec-scan-report
+++ b/scripts/sec-scan-report
@@ -7,19 +7,74 @@ if ! command -v jq &> /dev/null; then
     exit 1
 fi
 
-if [ "$#" -ne 3 ]; then
-    echo "Usage: $0 <trivy-report.json> <dependency-tree.json> <output-file.[sarif|md]>"
+usage() {
+    echo "Usage: $0 (-t|--trivy-report) <trivy-report.json> [(-o|--output) <output-file.md>] [(-d|--dependency-tree) <dependency-tree.json>]"
+    echo
+    echo "Options:"
+    echo "  -t, --trivy-report      Trivy report JSON file (required)"
+    echo "  -o, --output           Output markdown file (default: ./security-report.md)"
+    echo "  -d, --dependency-tree  Dependency tree JSON file (optional)"
+    echo "  -h, --help            Show this help message"
+    exit 1
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -t|--trivy-report)
+            TRIVY_FILE="$2"
+            shift 2
+            ;;
+        -o|--output)
+            REPORT_FILE="$2"
+            shift 2
+            ;;
+        -d|--dependency-tree)
+            DEPS_FILE="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Error: Unknown option $1" >&2
+            usage
+            ;;
+    esac
+done
+
+# Set default output file if not provided
+if [ -z "$REPORT_FILE" ]; then
+    REPORT_FILE="./security-report.md"
+fi
+
+# Check required parameters
+if [ -z "$TRIVY_FILE" ]; then
+    echo "Error: Missing required parameter: trivy report file" >&2
+    usage
+fi
+
+# Check if files exist
+if [ ! -f "$TRIVY_FILE" ]; then
+    echo "Error: Trivy report file '$TRIVY_FILE' not found" >&2
     exit 1
 fi
 
-TRIVY_FILE="$1"
-DEPS_FILE="$2"
-REPORT_FILE="$3"
+if [ -n "$DEPS_FILE" ] && [ ! -f "$DEPS_FILE" ]; then
+    echo "Error: Dependency tree file '$DEPS_FILE' not found" >&2
+    exit 1
+fi
 
 # Function to find dependency path in JSON tree
 find_dependency_path() {
     local pkg_name=$1
     local raw_paths
+
+    # If dependency tree file doesn't exist or is empty, return EXTERNAL
+    if [ -z "$DEPS_FILE" ] || [ ! -s "$DEPS_FILE" ]; then
+        echo '{"type": "EXTERNAL", "paths": []}'
+        return
+    fi
 
     # First try exact match
     raw_paths=$(jq -r --arg pkg "$pkg_name" '
@@ -42,20 +97,20 @@ find_dependency_path() {
             def find_paths($pkg; $current_path):
                 if (.text | type) == "string" and (.text | contains($pkg)) then
                     if $current_path == "" then $current_path + .text
-                    else $current_path + " -> " + .text
-                    end
-                elif (.children | type) == "array" then
-                    (.children[] | find_paths($pkg; if $current_path == "" then .text else $current_path + " -> " + .text end))
-                else
-                    empty
-                end;
-            [.[] | find_paths($pkg; "")] | unique | select(length > 0)
-        ' "$DEPS_FILE")
+                else $current_path + " -> " + .text
+                end
+            elif (.children | type) == "array" then
+                (.children[] | find_paths($pkg; if $current_path == "" then .text else $current_path + " -> " + .text end))
+            else
+                empty
+            end;
+        [.[] | find_paths($pkg; "")] | unique | select(length > 0)
+    ' "$DEPS_FILE")
     fi
 
     # Return dependency type and paths
     if [ -z "$raw_paths" ]; then
-        echo '{"type": "DIRECT", "paths": []}'
+        echo '{"type": "EXTERNAL", "paths": []}'
     else
         echo "$raw_paths" | jq -r '
             if (map(select(contains("com.raw-labs"))) | length > 0) then
@@ -74,153 +129,62 @@ find_dependency_path() {
 }
 
 # Generate markdown report
-generate_markdown() {
-    {
-        echo "# 🔍 Vulnerability Summary"
-        echo "Generated on: $(date)"
-        echo
+{
+    echo "# 🔍 Vulnerability Summary"
+    echo "Generated on: $(date)"
+    echo
 
-        # Print total count
-        total_vulns=$(jq -r '.Results[] | select(.Vulnerabilities) | .Vulnerabilities | length' "$TRIVY_FILE" | awk '{sum+=$1} END{print sum}')
-        echo "Found $total_vulns vulnerabilities"
-        echo
+    # Print total count
+    total_vulns=$(jq -r '.Results[] | select(.Vulnerabilities) | .Vulnerabilities | length' "$TRIVY_FILE" | awk '{sum+=$1} END{print sum}')
+    echo "Found $total_vulns vulnerabilities"
+    echo
 
-        # Group by dependency source
-        echo "## System Dependencies"
-        echo
-        while IFS= read -r vuln; do
-            pkg_name=$(echo "$vuln" | jq -r '.PkgName')
-            dep_info=$(find_dependency_path "$pkg_name")
-            if echo "$dep_info" | jq -e '.type == "DIRECT"' > /dev/null; then
-                echo "$vuln" | jq -r '"⚠️ \(.PkgName) (\(.Severity)) → Fixed in: \(.FixedVersion)"'
-            fi
-        done < <(jq -c '.Results[] | select(.Vulnerabilities) | .Vulnerabilities[]' "$TRIVY_FILE")
-        echo
-        echo "## Library Dependencies"
-        echo
-        echo "### From Raw Labs"
-        echo
+    # Group by dependency source
+    echo "## System Dependencies"
+    echo
+    while IFS= read -r vuln; do
+        echo "$vuln" | jq -r '"⚠️ \(.PkgName) (\(.Severity)) → Fixed in: \(.FixedVersion)"'
+    done < <(jq -c '.Results[] | select(.Class == "os-pkgs") | select(.Vulnerabilities) | .Vulnerabilities[]' "$TRIVY_FILE")
+    echo
+
+    echo "## Library Dependencies"
+    echo
+
+    # Only show Raw Labs section if dependency tree is provided
+    if [ -n "$DEPS_FILE" ] && [ -s "$DEPS_FILE" ]; then
+        has_rawlabs=false
         while IFS= read -r vuln; do
             pkg_name=$(echo "$vuln" | jq -r '.PkgName')
             dep_info=$(find_dependency_path "$pkg_name")
             if echo "$dep_info" | jq -e '.type == "RAWLABS"' > /dev/null; then
+                if [ "$has_rawlabs" = false ]; then
+                    echo "### From Raw Labs"
+                    echo
+                    has_rawlabs=true
+                fi
                 paths=$(echo "$dep_info" | jq -r '.paths | map("  • " + .) | join("\n")')
                 echo "$vuln" | jq -r '"⚠️ \(.PkgName) (\(.Severity)) → Fixed in: \(.FixedVersion)"'
                 echo "$paths"
                 echo
             fi
-        done < <(jq -c '.Results[] | select(.Vulnerabilities) | .Vulnerabilities[]' "$TRIVY_FILE")
-        echo
+        done < <(jq -c '.Results[] | select(.Class == "lang-pkgs") | select(.Vulnerabilities) | .Vulnerabilities[]' "$TRIVY_FILE")
 
-        echo "### From Third-party"
-        echo
-        while IFS= read -r vuln; do
-            pkg_name=$(echo "$vuln" | jq -r '.PkgName')
-            dep_info=$(find_dependency_path "$pkg_name")
-            if echo "$dep_info" | jq -e '.type == "EXTERNAL"' > /dev/null; then
-                echo "$vuln" | jq -r '"⚠️ \(.PkgName) (\(.Severity)) → Fixed in: \(.FixedVersion)"'
-            fi
-        done < <(jq -c '.Results[] | select(.Vulnerabilities) | .Vulnerabilities[]' "$TRIVY_FILE")
-    } > "$REPORT_FILE"
-}
+        if [ "$has_rawlabs" = true ]; then
+            echo "### From Third-party"
+            echo
+        fi
+    fi
 
-# Generate SARIF report
-generate_sarif() {
-    # Create a temporary file for the results array
-    TMP_RESULTS=$(mktemp)
-
-    # Process each vulnerability
+    # Print external dependencies
+    has_external=false
     while IFS= read -r vuln; do
         pkg_name=$(echo "$vuln" | jq -r '.PkgName')
         dep_info=$(find_dependency_path "$pkg_name")
-
-        # Create SARIF result with dependency path info
-        echo "$vuln" | jq -c --argjson dep_info "$dep_info" '
-        {
-          "ruleId": .VulnerabilityID,
-          "level": (if .Severity == "CRITICAL" then "error" elif .Severity == "HIGH" then "warning" else "note" end),
-          "message": {
-            "text": "\(.PkgName) (\(.Severity)) - \(.Title)"
-          },
-          "locations": [{
-            "physicalLocation": {
-              "artifactLocation": {
-                "uri": (
-                  if $dep_info.type == "DIRECT" then
-                    "system/\(.PkgName)"
-                  elif $dep_info.type == "RAWLABS" then
-                    "dependencies/\(.PkgName | gsub(":"; "/"))"
-                  else
-                    "external/\(.PkgName | gsub(":"; "/"))"
-                  end
-                )
-              }
-            }
-          }],
-          "properties": {
-            "dependencyType": $dep_info.type,
-            "fixedVersion": .FixedVersion,
-            "severity": .Severity,
-            "packageName": .PkgName,
-            "vulnerabilityId": .VulnerabilityID,
-            "title": .Title,
-            "description": (
-                if $dep_info.type == "RAWLABS" then
-                    "Dependency Chain(s):\n" + ($dep_info.paths | map("  • " + .) | join("\n")) + "\n\n" + .Description
-                else
-                    .Description
-                end
-            )
-          },
-          "fingerprints": {
-            "primaryLocationLineHash": .VulnerabilityID,
-            "primaryLocationStartLineFingerprint": .PkgName
-          }
-        }' >> "$TMP_RESULTS"
-    done < <(jq -c '.Results[] | select(.Vulnerabilities) | .Vulnerabilities[]' "$TRIVY_FILE")
-
-    # Create the final SARIF file
-    {
-        echo '{
-          "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
-          "version": "2.1.0",
-          "runs": [{
-            "tool": {
-              "driver": {
-                "name": "Trivy",
-                "informationUri": "https://github.com/aquasecurity/trivy"
-              }
-            },
-            "results": ['
-
-        # Add results with proper comma separation
-        paste -sd ',' "$TMP_RESULTS"
-
-        echo '        ]
-          }]
-        }'
-    } > "$REPORT_FILE"
-
-    # Clean up
-    rm "$TMP_RESULTS"
-
-    # Validate the SARIF file
-    if ! jq empty "$REPORT_FILE" 2>/dev/null; then
-        echo "Error: Generated SARIF file is not valid JSON"
-        exit 1
-    fi
-}
-
-# Determine output format based on file extension
-case "${REPORT_FILE##*.}" in
-    "md")
-        generate_markdown
-        ;;
-    "sarif")
-        generate_sarif
-        ;;
-    *)
-        echo "Error: Output file must have .md or .sarif extension"
-        exit 1
-        ;;
-esac
+        if echo "$dep_info" | jq -e '.type == "EXTERNAL"' > /dev/null; then
+            if [ "$has_external" = false ] && [ -n "$DEPS_FILE" ] && [ -s "$DEPS_FILE" ]; then
+                has_external=true
+            fi
+            echo "$vuln" | jq -r '"⚠️ \(.PkgName) (\(.Severity)) → Fixed in: \(.FixedVersion)"'
+        fi
+    done < <(jq -c '.Results[] | select(.Class == "lang-pkgs") | select(.Vulnerabilities) | .Vulnerabilities[]' "$TRIVY_FILE")
+} > "$REPORT_FILE"


### PR DESCRIPTION
- remove custom SARIF gen
- allow no dep tree input
- adaptative report if there is no raw-labs dependencies to chain